### PR TITLE
chore: Remove copyright appending from LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,29 +175,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2020-2024 Info Support
-   Copyright 2024 Stryker Mutator
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Pim Rheiter
+   Copyright 2024 Stryker Mutator
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,6 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
+   Copyright 2020 Info Support BV
    Copyright 2024 Stryker Mutator
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Info Support BV
+   Copyright 2020 Info Support
    Copyright 2024 Stryker Mutator
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Info Support
+   Copyright 2020-2024 Info Support
    Copyright 2024 Stryker Mutator
 
    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Copyright appendix is meant to add as a header to source files, it is not meant to be in the LICENSE file.